### PR TITLE
add fastjsonapi gem, add api, refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem "view_component"
 # Use Faraday [https://github.com/lostisland/faraday]
 gem "faraday"
 
+gem 'fast_jsonapi'
+
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -232,6 +234,7 @@ DEPENDENCIES
   capybara
   debug
   faraday
+  fast_jsonapi
   importmap-rails
   jbuilder
   puma (~> 5.0)

--- a/app/controllers/api/v1/pokemon_controller.rb
+++ b/app/controllers/api/v1/pokemon_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::PokemonController < ApplicationController
+  def index
+    pokemon = PokeFacade.get_a_pokemon(params[:name])
+    render json: PokemonSerializer.new(pokemon)
+  end
+end

--- a/app/facades/poke_facade.rb
+++ b/app/facades/poke_facade.rb
@@ -2,7 +2,8 @@ class PokeFacade
   class << self
     def get_a_pokemon(pokemon)
       data = PokeService.call_for_a_pokemon(pokemon)
-      pokemon = Pokemon.new(data)
+      poki = Pokemon.new(data)
+      Poki.find_or_create_pokemon(poki)
     end
   end
 end

--- a/app/models/poki.rb
+++ b/app/models/poki.rb
@@ -1,0 +1,17 @@
+class Poki < ApplicationRecord
+  validates_presence_of :name, :height, :weight, :base_experience, :image
+
+  class << self
+    def find_or_create_pokemon(poki)
+      find_or_initialize_by(
+        name: poki.name,
+        height: poki.height,
+        weight: poki.weight,
+        base_experience: poki.base_experience,
+        image: poki.image
+      ).tap do |pokemon|
+        pokemon.save! if pokemon.new_record?
+      end
+    end
+  end
+end

--- a/app/serializers/pokemon_serializer.rb
+++ b/app/serializers/pokemon_serializer.rb
@@ -1,0 +1,4 @@
+class PokemonSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name, :base_experience, :image
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
   root 'welcome#index'
 
-  get 'searches/index'
   resources :pokemon, only: [:index]
+
+  namespace :api do
+    namespace :v1 do
+      resources :pokemon, only: :index
+    end
+  end
 end

--- a/db/migrate/20231116182328_create_pokis.rb
+++ b/db/migrate/20231116182328_create_pokis.rb
@@ -1,0 +1,13 @@
+class CreatePokis < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pokis do |t|
+      t.string :name
+      t.integer :height
+      t.integer :weight
+      t.integer :base_experience
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_182328) do
+  create_table "pokis", force: :cascade do |t|
+    t.string "name"
+    t.integer "height"
+    t.integer "weight"
+    t.integer "base_experience"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/fixtures/pokis.yml
+++ b/test/fixtures/pokis.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  height: 1
+  weight: 1
+  base_experience: 1
+  image: MyString
+
+two:
+  name: MyString
+  height: 1
+  weight: 1
+  base_experience: 1
+  image: MyString

--- a/test/models/poki_test.rb
+++ b/test/models/poki_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PokiTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
add fast_jsonapi gem
add api/v1/pokemon_controller.rb
add api/v1 routes
add poki model 
add pokemon serializer
refactor facade
run migration

all this was with the intention of make an endpoint for external consume, with a workaround to avoid more than one request to PokeApi when it's the same Pokemon, then the first request will create an instance of that Pokemon in our db, then the second request, its going over db first.
Serializer, its just to resume information, not another meaning.
